### PR TITLE
#2 updated test containers version, scala version, scala test version an…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .*
 build/
 *.iml
+out

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
             "org.scalatest:scalatest_2.11:$scalaTestVersion",
             "org.testcontainers:mysql:$testcontainersVersion")
 
-    testCompile("junit:junit:4.11",
+    testCompile("junit:junit:4.12",
             "org.testcontainers:selenium:$testcontainersVersion",
             "mysql:mysql-connector-java:$mysqlConnectorVersion",
             "org.mockito:mockito-all:$mockitoVersion")

--- a/build.gradle
+++ b/build.gradle
@@ -34,10 +34,11 @@ dependencies {
             "org.seleniumhq.selenium:selenium-java:$seleniumVersion",
             "org.testcontainers:selenium:$testcontainersVersion",
             "org.slf4j:slf4j-simple:$slf4jVersion",
-            "org.scalatest:scalatest_2.11:$scalaTestVersion",
+            "org.scalatest:scalatest_2.12:$scalaTestVersion",
             "org.testcontainers:mysql:$testcontainersVersion")
 
     testCompile("junit:junit:4.12",
+            "org.scala-lang:scala-library:$scalaVersion",
             "org.testcontainers:selenium:$testcontainersVersion",
             "mysql:mysql-connector-java:$mysqlConnectorVersion",
             "org.mockito:mockito-all:$mockitoVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,10 @@ version = 0.4.0
 
 archivesBaseName = "testcontainers-scala"
 
-testcontainersVersion = 1.1.5
-scalaVersion = 2.11.8
+testcontainersVersion = 1.1.7
+scalaVersion = 2.12.1
 seleniumVersion = 2.53.0
 slf4jVersion = 1.7.21
-scalaTestVersion = 2.2.6
+scalaTestVersion = 3.0.1
 mysqlConnectorVersion = 5.1.39
 mockitoVersion = 1.10.19

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 06 20:02:01 EDT 2016
+#Wed Dec 21 18:16:36 EET 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip

--- a/src/test/scala/com/dimafeng/testcontainers/ContainerSpec.scala
+++ b/src/test/scala/com/dimafeng/testcontainers/ContainerSpec.scala
@@ -4,7 +4,7 @@ import org.junit.runner.{Description, RunWith}
 import org.mockito.Matchers.any
 import org.mockito.{Matchers, Mockito}
 import org.mockito.Mockito.{times, verify}
-import org.scalatest.mock.MockitoSugar._
+import org.scalatest.mockito.MockitoSugar._
 import org.scalatest.{Reporter, Args, FlatSpec}
 import org.scalatest.junit.JUnitRunner
 import org.testcontainers.containers.{GenericContainer => OTCGenericContainer}


### PR DESCRIPTION
…d ContainerSpec to update it to use new mockito api from scala test.

I've done updates of the libraries, compile works fine, the unit test (ContainerSpec) could not be started. I never used gradle before, so it could be because of the version of it or something else.